### PR TITLE
Add streaming transcription support

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -51,11 +51,15 @@ Transcribe any audio file using a chosen model.
 
 * `file`: audio file (`.mp3`, `.wav`, etc.)
 * `model`: model name (default: `base`)
+* `stream`: return results progressively when `true`
 
 #### Example using curl
 
 ```bash
+# regular response
 curl.exe -F "file=@C:/path/to/audio.mp3" "http://localhost:7653/transcribe?model=base"
+# streaming response
+curl.exe -N -F "file=@C:/path/to/audio.mp3" "http://localhost:7653/transcribe?model=base&stream=true"
 ```
 
 #### Example Response
@@ -98,7 +102,7 @@ The server cleanly shuts down:
 
 * Add `/status` endpoint to monitor queue size and model usage
 * Add TTL-based expiration to cache
-* Support streaming or chunked transcription
+* ~~Support streaming or chunked transcription~~ (done)
 
 ---
 


### PR DESCRIPTION
## Summary
- add StreamingResponse support via optional `stream` parameter
- stream transcription results back as they are produced
- document new streaming capability in ReadMe

## Testing
- `python -m py_compile main.py whisperclient/transcriber.py`


------
https://chatgpt.com/codex/tasks/task_e_68551c120d848325be8c3a792c63f29f