### PR TITLE
Add optional word timestamps

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -52,12 +52,15 @@ Transcribe any audio file using a chosen model.
 * `file`: audio file (`.mp3`, `.wav`, etc.)
 * `model`: model name (default: `base`)
 * `stream`: return results progressively when `true`
+* `words`: include word-level timestamps when `true`
 
 #### Example using curl
 
 ```bash
 # regular response
 curl.exe -F "file=@C:/path/to/audio.mp3" "http://localhost:7653/transcribe?model=base"
+# with word timestamps
+curl.exe -F "file=@C:/path/to/audio.mp3" "http://localhost:7653/transcribe?model=base&words=true"
 # streaming response
 curl.exe -N -F "file=@C:/path/to/audio.mp3" "http://localhost:7653/transcribe?model=base&stream=true"
 ```

--- a/main.py
+++ b/main.py
@@ -102,7 +102,7 @@ def model_worker(request_queue, response_queue, stop_event):
                             temp_path,
                             beam_size=beam_size,
                             language=lang,
-                            word_timestamps=True,
+                            word_timestamps=request.get("words", False),
                             condition_on_previous_text=False,
                         )
                         all_segments = []
@@ -115,7 +115,7 @@ def model_worker(request_queue, response_queue, stop_event):
                                 "text": seg.text,
                             }
                             all_segments.append(seg_data)
-                            if seg.words:
+                            if request.get("words", False) and getattr(seg, "words", None):
                                 words = [
                                     {"start": w.start, "end": w.end, "word": w.word}
                                     for w in seg.words
@@ -125,19 +125,19 @@ def model_worker(request_queue, response_queue, stop_event):
                                 words = []
 
                             if stream:
-                                response_queue.put({
-                                    "request_id": request_id,
-                                    "segment": seg_data,
-                                    "words": words,
-                                })
+                                payload = {"request_id": request_id, "segment": seg_data}
+                                if request.get("words", False):
+                                    payload["words"] = words
+                                response_queue.put(payload)
 
                         result = {
                             "text": " ".join([s["text"] for s in all_segments]),
                             "segments": all_segments,
-                            "words": all_words,
                             "language": info.language,
-                            "language_probability": info.language_probability
+                            "language_probability": info.language_probability,
                         }
+                        if request.get("words", False):
+                            result["words"] = all_words
 
                         if cache_key:
                             cache[cache_key] = result
@@ -180,7 +180,10 @@ async def response_listener(stop_event):
                     await queue.put(None)
                     pending_streams.pop(request_id, None)
                 elif "segment" in result:
-                    await queue.put({"segment": result["segment"], "words": result.get("words", [])})
+                    payload = {"segment": result["segment"]}
+                    if "words" in result:
+                        payload["words"] = result["words"]
+                    await queue.put(payload)
                 elif result.get("final"):
                     await queue.put({"result": result["result"]})
                     await queue.put(None)
@@ -211,6 +214,7 @@ async def transcribe(
     language: Optional[str] = Query(None),
     beam_size: Optional[int] = Query(5),
     stream: bool = Query(False),
+    words: bool = Query(False),
     api_key:str=Query(...),
 ):
     if api_key not in ALLOWED_API_KEYS:
@@ -220,7 +224,7 @@ async def transcribe(
 
     audio_bytes = await file.read()
     audio_hash = hash_bytes(audio_bytes)
-    cache_key = f"{model}:{language}:{audio_hash}"
+    cache_key = f"{model}:{language}:{words}:{audio_hash}"
 
     if cache_key in cache and not stream:
         logger.info(f"[CACHE HIT] {cache_key}")
@@ -248,6 +252,7 @@ async def transcribe(
         "cache_key": cache_key,
         "beam_size": beam_size,
         "stream": stream,
+        "words": words,
     })
 
     if stream:


### PR DESCRIPTION
## Summary
- make word timestamps optional via `words` query parameter
- document `words` parameter in API docs

## Testing
- `python -m py_compile main.py whisperclient/transcriber.py`


------
https://chatgpt.com/codex/tasks/task_e_68551fc5302c832599f578833207d3bc