### PR TITLE
Add streaming fallback for local model

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,18 @@ pip install bezrabotnyiwhisper  # после публикации
 
 ## Использование
 ```python
-from whisperclient import transcribe_sync
-whisperclient.api_key='secret-key'
+from whisperclient import transcribe_sync, transcribe_stream_sync
+import whisperclient
+
+# Настраиваем ключ и модель
+whisperclient.api_key = 'secret-key'
+whisperclient.model = 'large-v3'
+
+# Обычная расшифровка
 text = transcribe_sync("audio.ogg")
 print(text)
+
+# Стриминг-режим
+for chunk in transcribe_stream_sync("audio.ogg"):
+    print(chunk)
 ```

--- a/whisperclient/__init__.py
+++ b/whisperclient/__init__.py
@@ -1,5 +1,14 @@
-from .transcriber import transcribe_sync, transcribe_with_fallback, voice_to_text
+from .transcriber import (
+    transcribe_sync,
+    transcribe_with_fallback,
+    voice_to_text,
+    transcribe_stream_sync,
+    transcribe_stream_with_fallback,
+)
 
-# Глобальная переменная для API-ключа (можно менять снаружи)
+# Глобальные переменные для настройки клиента (API‑ключ и модель)
 import os
+
 api_key = os.getenv("API_KEY", "bad-key")
+# Модель по умолчанию используется при обращении к серверу
+model = os.getenv("MODEL", "large-v3")

--- a/whisperclient/transcriber.py
+++ b/whisperclient/transcriber.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import json
 import tempfile
-from typing import Optional
+from typing import AsyncGenerator, Generator, Optional
+import threading
 
 import aiohttp
 import requests
 from faster_whisper import WhisperModel
 import whisperclient
+
 _MODEL: Optional[WhisperModel] = None
 
 
@@ -28,21 +31,88 @@ def _transcribe(path: str) -> str:
     return " ".join(s.text.strip() for s in segments)
 
 
-def transcribe_sync(file_path: str, model: str = "large-v3", language: Optional[str] = None,api_key=None) -> str:
+def _transcribe_stream(path: str) -> Generator[dict, None, None]:
+    """Local streaming transcription yielding results in server format."""
+    model = _get_model()
+    segments, info = model.transcribe(
+        path,
+        beam_size=5,
+        word_timestamps=True,
+        condition_on_previous_text=False,
+    )
+
+    all_segments = []
+    all_words = []
+    for seg in segments:
+        seg_data = {"start": seg.start, "end": seg.end, "text": seg.text}
+        all_segments.append(seg_data)
+        if seg.words:
+            words = [
+                {"start": w.start, "end": w.end, "word": w.word} for w in seg.words
+            ]
+            all_words.extend(words)
+        else:
+            words = []
+        yield {"segment": seg_data, "words": words}
+
+    result = {
+        "text": " ".join(s["text"] for s in all_segments),
+        "segments": all_segments,
+        "words": all_words,
+        "language": info.language,
+        "language_probability": info.language_probability,
+    }
+    yield {"result": result}
+
+
+async def _transcribe_stream_async(path: str) -> AsyncGenerator[dict, None]:
+    """Asynchronous wrapper around :func:`_transcribe_stream`."""
+    loop = asyncio.get_event_loop()
+    queue: asyncio.Queue = asyncio.Queue()
+
+    def worker() -> None:
+        try:
+            for item in _transcribe_stream(path):
+                loop.call_soon_threadsafe(queue.put_nowait, item)
+        finally:
+            loop.call_soon_threadsafe(queue.put_nowait, None)
+
+    thread = threading.Thread(target=worker, daemon=True)
+    thread.start()
+
+    while True:
+        item = await queue.get()
+        if item is None:
+            break
+        yield item
+    thread.join()
+
+
+def transcribe_sync(
+    file_path: str,
+    language: Optional[str] = None,
+    api_key: Optional[str] = None,
+    model: Optional[str] = None,
+) -> str:
     url = "https://whisper.bezrabotnyi.com/transcribe"
     key = api_key or whisperclient.api_key
-    params = {"model": model, "api_key": key}
+    model_name = model or whisperclient.model
+    params = {"model": model_name, "api_key": key}
     if language:
         params["language"] = language
 
     try:
         with open(file_path, "rb") as f:
-            files = {"file": (os.path.basename(file_path), f, "application/octet-stream")}
+            files = {
+                "file": (os.path.basename(file_path), f, "application/octet-stream")
+            }
             response = requests.post(url, files=files, params=params, timeout=600)
             if response.ok:
                 return response.json()["text"]
             else:
-                logging.warning(f"[Whisper сервер ответил {response.status_code}] {response.text}")
+                logging.warning(
+                    f"[Whisper сервер ответил {response.status_code}] {response.text}"
+                )
     except Exception:
         logging.warning("Ошибка при обращении к удалённому whisper", exc_info=True)
 
@@ -54,7 +124,54 @@ def transcribe_sync(file_path: str, model: str = "large-v3", language: Optional[
         return "[TRANSCRIPTION ERROR]"
 
 
-async def voice_to_text(message) -> str:#For aiogram uses
+def transcribe_stream_sync(
+    file_path: str,
+    language: Optional[str] = None,
+    api_key: Optional[str] = None,
+    model: Optional[str] = None,
+) -> Generator[dict, None, None]:
+    """Stream transcription results from the remote server.
+
+    Yields dictionaries received from the server in real time. Falls back to a
+    one-shot local transcription if the request fails.
+    """
+    url = "https://whisper.bezrabotnyi.com/transcribe"
+    key = api_key or whisperclient.api_key
+    model_name = model or whisperclient.model
+    params = {"model": model_name, "api_key": key, "stream": "true"}
+    if language:
+        params["language"] = language
+
+    try:
+        with open(file_path, "rb") as f:
+            files = {
+                "file": (os.path.basename(file_path), f, "application/octet-stream")
+            }
+            with requests.post(
+                url, files=files, params=params, timeout=600, stream=True
+            ) as resp:
+                if resp.ok:
+                    for line in resp.iter_lines():
+                        if line:
+                            yield json.loads(line.decode("utf-8"))
+                    return
+                else:
+                    logging.warning(
+                        f"[Whisper сервер ответил {resp.status_code}] {resp.text}"
+                    )
+    except Exception:
+        logging.warning("Ошибка при обращении к удалённому whisper", exc_info=True)
+
+    logging.info("Пробуем локальную расшифровку...")
+    try:
+        for item in _transcribe_stream(file_path):
+            yield item
+    except Exception:
+        logging.exception("Локальный whisper тоже не сработал")
+        yield {"result": {"text": "[TRANSCRIPTION ERROR]"}}
+
+
+async def voice_to_text(message) -> str:  # For aiogram uses
     with tempfile.NamedTemporaryFile(suffix=".ogg", delete=False) as tmp:
         file_path = tmp.name
 
@@ -71,10 +188,16 @@ async def voice_to_text(message) -> str:#For aiogram uses
     return text
 
 
-async def transcribe_with_fallback(file_path: str, model: str = "large-v3", language: Optional[str] = None,api_key=None) -> str:
+async def transcribe_with_fallback(
+    file_path: str,
+    language: Optional[str] = None,
+    api_key: Optional[str] = None,
+    model: Optional[str] = None,
+) -> str:
     url = "https://whisper.bezrabotnyi.com/transcribe"
     key = api_key or whisperclient.api_key
-    data = {"model": model, "api_key": key}
+    model_name = model or whisperclient.model
+    data = {"model": model_name, "api_key": key}
     if language:
         data["language"] = language
 
@@ -82,15 +205,24 @@ async def transcribe_with_fallback(file_path: str, model: str = "large-v3", lang
         async with aiohttp.ClientSession() as session:
             with open(file_path, "rb") as f:
                 form = aiohttp.FormData()
-                form.add_field("file", f, filename=os.path.basename(file_path), content_type="application/octet-stream")
+                form.add_field(
+                    "file",
+                    f,
+                    filename=os.path.basename(file_path),
+                    content_type="application/octet-stream",
+                )
 
-                async with session.post(url, data=form, params=data, timeout=600) as resp:
+                async with session.post(
+                    url, data=form, params=data, timeout=600
+                ) as resp:
                     if resp.status == 200:
                         result = await resp.json()
                         return result["text"]
                     else:
                         error_text = await resp.text()
-                        logging.warning(f"[Whisper сервер ответил {resp.status}] {error_text}")
+                        logging.warning(
+                            f"[Whisper сервер ответил {resp.status}] {error_text}"
+                        )
     except Exception:
         logging.warning("Ошибка при обращении к удалённому whisper", exc_info=True)
 
@@ -103,6 +235,56 @@ async def transcribe_with_fallback(file_path: str, model: str = "large-v3", lang
         return "[TRANSCRIPTION ERROR]"
 
 
-if __name__ == '__main__':
+async def transcribe_stream_with_fallback(
+    file_path: str,
+    language: Optional[str] = None,
+    api_key: Optional[str] = None,
+    model: Optional[str] = None,
+) -> AsyncGenerator[dict, None]:
+    """Asynchronously stream transcription results with local fallback."""
+    url = "https://whisper.bezrabotnyi.com/transcribe"
+    key = api_key or whisperclient.api_key
+    model_name = model or whisperclient.model
+    params = {"model": model_name, "api_key": key, "stream": "true"}
+    if language:
+        params["language"] = language
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            with open(file_path, "rb") as f:
+                form = aiohttp.FormData()
+                form.add_field(
+                    "file",
+                    f,
+                    filename=os.path.basename(file_path),
+                    content_type="application/octet-stream",
+                )
+                async with session.post(
+                    url, data=form, params=params, timeout=600
+                ) as resp:
+                    if resp.status == 200:
+                        async for line in resp.content:
+                            line = line.decode("utf-8").strip()
+                            if line:
+                                yield json.loads(line)
+                        return
+                    else:
+                        error_text = await resp.text()
+                        logging.warning(
+                            f"[Whisper сервер ответил {resp.status}] {error_text}"
+                        )
+    except Exception:
+        logging.warning("Ошибка при обращении к удалённому whisper", exc_info=True)
+
+    logging.info("Пробуем локальную расшифровку...")
+    try:
+        async for item in _transcribe_stream_async(file_path):
+            yield item
+    except Exception:
+        logging.exception("Локальный whisper тоже не сработал")
+        yield {"result": {"text": "[TRANSCRIPTION ERROR]"}}
+
+
+if __name__ == "__main__":
     t = transcribe_sync("/tmp/test.ogg")
     print(t)


### PR DESCRIPTION
## Summary
- add `_transcribe_stream` and async wrapper to stream local segments
- use local streaming transcription when remote streaming fails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68551f68203883258e85edd756d05b70